### PR TITLE
Appearance: get/set animations from interface key

### DIFF
--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -420,10 +420,14 @@ public class PantheonShell.Appearance : Switchboard.SettingsPage {
         child = grid;
         add_css_class ("appearance-view");
 
+        // This key should be deprecated. Set only because interface settings is the source of truth
         var animations_settings = new Settings ("io.elementary.desktop.wm.animations");
-        animations_settings.bind ("enable-animations", animations_switch, "active", SettingsBindFlags.INVERT_BOOLEAN);
+        animations_switch.notify["active"].connect (() => {
+            animations_settings.set_boolean ("enable-animations", !animations_switch.active);
+        });
 
         interface_settings.bind ("overlay-scrolling", scrollbar_switch, "active", INVERT_BOOLEAN);
+        interface_settings.bind ("enable-animations", animations_switch, "active", INVERT_BOOLEAN);
 
         var background_settings = new GLib.Settings ("io.elementary.desktop.background");
         background_settings.bind ("dim-wallpaper-in-dark-style", dim_switch, "active", DEFAULT);


### PR DESCRIPTION
We had a separate WM key and didn't set this one historically because there was a GTK bug that caused revealers to reserve extra blank space when animations were disabled. That bug appears to be fixed, so this massively increases the amount of animations that are disabled

Looks like we can't use bind with two settings objects? So that's why I switched to a property notify instead of bind with `SET`