### PR TITLE
deb-packaging: sync old and new enable-animations keys

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+gsettings set org.gnome.desktop.interface enable-animations $(gsettings get io.elementary.desktop.wm.animations enable-animations) || true
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
Fixes https://github.com/elementary/settings-desktop/issues/439

I accidentally pushed and removed this change from deb-pakaging branch. Sorry about that. I forgot there's no push protection.